### PR TITLE
Add support for all API parameters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,6 @@ script:
   - ./vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
 
 after_script:
-  - wget https://scrutinizer-ci.com/ocular.phar
-  - php ocular.phar code-coverage:upload --format=php-clover coverage.clover
+  - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ] && [ "$TRAVIS_PHP_VERSION" != "7.0" ]; then wget https://scrutinizer-ci.com/ocular.phar; fi
+  - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ] && [ "$TRAVIS_PHP_VERSION" != "7.0" ]; then php ocular.phar code-coverage:upload --format=php-clover coverage.clover; fi
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,23 @@
 # Changelog
 All Notable changes to `jobs-indeed` will be documented in this file
 
+## 0.4.0 - 2015-08-31
+
+### Added
+- Support for all query parameters available on the Indeed `http://api.indeed.com/ads/apisearch` resource
+
+### Deprecated
+- Nothing
+
+### Fixed
+- Nothing
+
+### Removed
+- Nothing
+
+### Security
+- Nothing
+
 ## 0.3.6 - 2015-08-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -24,16 +24,30 @@ Usage is the same as Job Branders's Jobs Client, using `\JobBrander\Jobs\Client\
 
 ```php
 $client = new JobBrander\Jobs\Client\Provider\Indeed([
-    'publisherId' => 'YOUR INDEED PUBLISHER ID',
-    'version' => 2,
+    'publisher' => 'YOUR INDEED PUBLISHER ID',
+    'v' => 2, // Optional. Default is 2.
     'highlight' => 0,
 ]);
 
-// Search for 200 job listings for 'project manager' in Chicago, IL
-$jobs = $client->setKeyword('project manager') // Query. By default terms are ANDed. To see what is possible, use the [advanced search page](http://www.indeed.com/advanced_search) to perform a search and then check the url for the q value.
-    ->setCity('Chicago')        // Location uses a postal code or a "city, state/province/region" combination
-    ->setState('IL')            // Location uses a postal code or a "city, state/province/region" combination
-    ->setCount(200)             // Maximum number of results returned per query. Default is 10
+$jobs = $client
+    ->setKeyword('project manager')                 // Query. By default terms are ANDed. To see what is possible, use the [advanced search page](http://www.indeed.com/advanced_search) to perform a search and then check the url for the q value.
+    ->setFormat('json')                             // Format. Which output format of the API you wish to use. The options are "xml" and "json". If omitted or invalid, the json format is used.
+    ->setCity('Chicago')                            // City.
+    ->setState('IL')                                // State.
+    ->setLocation('Chicago, IL')                    // Location. Use a postal code or a "city, state/province/region" combination. Will overwrite any changes made using setCity and setState
+    ->setSort('date')                               // Sort by relevance or date. Default is relevance.
+    ->setRadius('100')                              // Distance from search location ("as the crow flies"). Default is 25.
+    ->setSiteType('jobsite')                        // Site type. To show only jobs from job boards use "jobsite". For jobs from direct employer websites use "employer".
+    ->setJobType('fulltime')                        // Job type. Allowed values: "fulltime", "parttime", "contract", "internship", "temporary".
+    ->setPage(2)                                    // Start results at this result number, beginning with 0. Default is 0.
+    ->setCount(200)                                 // Maximum number of results returned per query. Default is 10
+    ->setDaysBack(10)                               // Number of days back to search.
+    ->filterDuplicates(false)                       // Filter duplicate results. 0 turns off duplicate job filtering. Default is 1.
+    ->includeLatLong(true)                          // If latlong=1, returns latitude and longitude information for each job result. Default is 0.
+    ->setCountry('us')                              // Search within country specified. Default is us.
+    ->setChannel('channel-one')                     // Channel Name: Group API requests to a specific channel
+    ->setUserIp($_SERVER['REMOTE_ADDR'])            // The IP number of the end-user to whom the job results will be displayed.
+    ->setUserAgent($_SERVER['HTTP_USER_AGENT'])     // The User-Agent (browser) of the end-user to whom the job results will be displayed.
     ->getJobs();
 ```
 


### PR DESCRIPTION
As referenced in #1 

This change provides support for each of the query string params included in the documentation for the associated resource, with the following exceptions:
- Any changes made to the client using `setLocation` will overwrite any previous changes made using `setCity` and `setState`.
- The client will attempt to include `userip` and `useragent` from the `$_SERVER` global variable if those parameters are not set using the setter methods.
